### PR TITLE
Support delayed scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The library is designed to enable a simple use pattern:
 1. Create a `ThreadPool` object.
 2. Give tasks to the pool by calling the pool's `schedule()`, `schedule_subtask()`, or `schedule_after()` methods.
 3. Wait for tasks to complete.
+
 Full documentation for this library may be generated using  Doxygen.
 
 A simple example of how to the library follows:

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Either compile thread_pool.cpp as part of your project, or [compile it as a stat
 
 The library is designed to enable a simple use pattern:
 1. Create a `ThreadPool` object.
-2. Give tasks to the pool by calling `ThreadPool.schedule(task)`.
+2. Give tasks to the pool by calling the pool's `schedule()`, `schedule_subtask()`, or `schedule_after()` methods.
 3. Wait for tasks to complete.
-Note that tasks can
-Full documentation for this library may be generated using  Doxygen. A simple example of how to the library follows:
+Full documentation for this library may be generated using  Doxygen.
+
+A simple example of how to the library follows:
 ```
 #include "thread_pool.hpp"
 
@@ -38,6 +39,13 @@ pool.schedule([](void)
  
 //  Put a task into the pool, treated as if it were part of the currently running task. This is called from within a worker thread, so it takes the scheduler's fast path.
   pool.schedule_subtask([](void) {
+    do_something();
+  });
+
+//  Put a task into the pool, to be executed 2 seconds after it is scheduled.
+  using namespace std::chrono;
+  pool.schedule_after(seconds(2),
+  [](void) {
     do_something();
   });
 });

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -85,12 +85,12 @@ int main()
         executed_tasks[i].store(0, std::memory_order_release);
       bool already_idling = false;
 
-      LOG("\t%s","Scheduling some tasks...");
+      LOG("\tScheduling some %s tasks...", (nn == 0) ? "immediate" : "delayed");
       pool.schedule([&](void)
       {
         for (unsigned i = 0; i < kTestRootTasks; ++i)
         {
-          pool.schedule([&](void)
+          pool.schedule_after(std::chrono::seconds(nn), [&](void)
           {
             for (unsigned j = 0; j < kTestBranchFactor; ++j)
             {
@@ -114,10 +114,10 @@ int main()
         uint_fast64_t balance_min, balance_max, balance_total;
         gather_statistics(balance_min, balance_max, balance_total);
         LOG("\t\tCompleted %llu / %llu tasks so far.", balance_total, kTestTotalTasks);
-        if (pool.is_idle())
+        if (pool.is_idle() && (balance_total == kTestTotalTasks))
         {
           gather_statistics(balance_min, balance_max, balance_total);
-          LOG("\tPool has idled, as expected (%llu / %llu tasks complete.", balance_total, kTestTotalTasks);
+          LOG("\tPool has idled, as expected, with all %llu tasks complete.", kTestTotalTasks);
           LOG("\tProcessor utilization [min / mean / max]:\t%llu / %llu / %llu", balance_min, balance_total / pool.get_concurrency(), balance_max);
           break;
         }

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -28,6 +28,7 @@ void perform_task (void);
 void gather_statistics  (uint_fast64_t & balance_min,
                          uint_fast64_t & balance_max,
                          uint_fast64_t & balance_total);
+void stay_active (ThreadPool &);
 
 thread_local std::atomic<uint_fast64_t> * task_slot_local = nullptr;
 std::atomic<uint_fast32_t> task_slot_next(0);
@@ -127,9 +128,9 @@ int main()
       unsigned total_ms = 0;
       for (unsigned ii = 0; ii < 9; ++ii)
       {
-        using namespace std::chrono_literals;
+        using namespace std::chrono;
         unsigned sleep_ms = (100 << ii);
-        std::this_thread::sleep_for(1ms * sleep_ms);
+        std::this_thread::sleep_for(milliseconds(sleep_ms));
         total_ms += sleep_ms;
 
         LOG("\t\t%s","Checking whether tasks are completed...");

--- a/threadpool.cpp
+++ b/threadpool.cpp
@@ -871,6 +871,14 @@ ThreadPoolImpl::ThreadPoolImpl (Worker * workers, unsigned threads)
 
 ThreadPoolImpl::~ThreadPoolImpl (void)
 {
+#ifndef NDEBUG
+  if ((current_worker != nullptr) && current_worker->belongs_to(this))
+  {
+    std::printf("ERROR!\tA worker thread may not destroy the ThreadPool to \
+which it belongs.\n");
+    std::abort();
+  }
+#endif
   std::unique_lock<decltype(mutex_)> guard (mutex_);
   stop_threads(guard);
   for (unsigned i = 0; i < threads_; ++i)

--- a/threadpool.hpp
+++ b/threadpool.hpp
@@ -32,6 +32,19 @@
 /// //  running task. This is called from within a worker thread, so no
 /// //  synchronization is required.
 ///   pool.schedule_subtask([](void) { });
+///
+/// //  Put a task into the pool, to be executed 2 seconds after it is scheduled.
+///  using namespace std::chrono;
+///  pool.schedule_after(seconds(2),
+///  [](void) {
+///    do_something();
+///  });
+///
+/// //    Put a task into the pool, to be executed at the specified time.
+///   pool.schedule_after(steady_clock::now() + seconds(2),
+///   [](void) {
+///     do_something();
+///   });
 /// });
 ///
 /// //    When the thread pool is destroyed, remaining tasks are forgotten.
@@ -53,9 +66,9 @@
 /// \todo Investigate delegates as a replacement for std::function:
 ///   <a href=https://www.codeproject.com/Articles/1170503/The-Impossibly-Fast-Cplusplus-Delegates-Fixed>"The Impossibly Fast C++ Delegates (Fixed)"</href>
 /// \author Nathaniel J. McClatchey, PhD
-/// \version  1.2.0
-/// \copyright Copyright (c) 2017 Nathaniel J. McClatchey, PhD.  \n
-///   Licensed under the MIT license. \n
+/// \version  1.3.0
+/// \copyright Copyright (c) 2017 Nathaniel J. McClatchey, PhD.               \n
+///   Licensed under the MIT license.                                         \n
 ///   You should have received a copy of the license with this software.
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -70,6 +83,8 @@
 #include <functional>
 //  For std::size_t
 #include <cstddef>
+//  For timed waiting.
+#include <chrono>
 //#include <future>
 
 /// \brief A high-performance asynchronous task scheduler.
@@ -92,10 +107,8 @@
 //  will impose a pointer lookup penalty, but only on the slow path. Moreover,
 //  dynamic allocation is required regardless, and all initial allocation is
 //  combined into a single allocation.
-class ThreadPool
+struct ThreadPool
 {
-  void * impl_;
- public:
 /// \brief  A Callable type, taking no arguments and returning void. Used to
 ///   store tasks for later execution.
   typedef std::function<void()> task_type;
@@ -133,6 +146,44 @@ class ThreadPool
   void schedule (const task_type & task);
 /// \overload
   void schedule (task_type && task);
+
+/// \brief  Schedules a task to be run asynchronously after a specified wait
+///   duration.
+/// \param[in]  rel_time  The duration after which the task is to be run.
+/// \param[in]  task  The task to be performed.
+///
+///   Schedules a task to be performed asynchronously, but only after waiting
+/// for a duration of *rel_time*.
+/// \par  Memory order
+///   Execution of a task *synchronizes-with* (as in `std::memory_order`) the
+/// call to `schedule_after()` that added it to the pool, using a
+/// *Release-Acquire* ordering.
+  template<class Rep, class Period, class Task>
+  void schedule_after ( const std::chrono::duration<Rep, Period> & rel_time,
+                        Task && task)
+  {
+    using namespace std;
+    sched_impl(chrono::duration_cast<duration>(rel_time), forward<Task>(task));
+  }
+
+/// \brief  Schedules a task to be run asynchronously at (or after) a specified
+///   point in time.
+/// \param[in]  time  The time point after which the task is to be run.
+/// \param[in]  task  The task to be performed.
+///
+///   Schedules a task to be performed asynchronously at a specified time point.
+/// \par  Memory order
+///   Execution of a task *synchronizes-with* (as in `std::memory_order`) the
+/// call to `schedule_after()` that added it to the pool, using a
+/// *Release-Acquire* ordering.
+  template<class Clock, class Duration, class Task>
+  void schedule_after ( const std::chrono::time_point<Clock, Duration> & time,
+                        Task && task)
+  {
+    using namespace std;
+    using namespace std::chrono;
+    sched_impl(duration_cast<duration>(time-Clock::now()), forward<Task>(task));
+  }
 
 /// \brief  Schedules a task to be run asynchronously, but with a hint that the
 ///   task ought to be considered part of the currently-scheduled task.
@@ -193,6 +244,11 @@ class ThreadPool
 /// the pool are simultaneously idling, or fales if at least one thread is
 /// active. May return \c false spuriously.
   bool is_idle (void) const;
+ private:
+  void * impl_;
+  typedef std::chrono::steady_clock::duration duration;
+  void sched_impl ( const duration &, const task_type &);
+  void sched_impl ( const duration &, task_type && task);
 };
 
 #endif // THREAD_POOL_HPP_

--- a/threadpool.hpp
+++ b/threadpool.hpp
@@ -75,6 +75,10 @@
 #ifndef THREAD_POOL_HPP_
 #define THREAD_POOL_HPP_
 
+#if !defined(__cplusplus) || (__cplusplus < 201103L)
+#error  "The ThreadPool library requires C++11 or higher."
+#endif
+
 //    For a unified interface to Callable objects, I considered 3 options:
 //  * Delegates (fast, but would need extra library and wouldn't allow return)
 //  * std::function (universally available, but doesn't allow return)


### PR DESCRIPTION
Because using blocking delaying functions such as `std::this_thread::sleep_for()` in a thread pool would severely affect performance, and because repeatedly re-scheduling would use excessive CPU, I have implemented functions that allow tasks to be scheduled on a delay -- that is, after a certain amount of time -- or at a specified time point.

In addition to this feature, this PR fixes several bugs, primarily those introduced in [the commit that moved to constructing and destroying task slots](https://github.com/nmcclatchey/ThreadPool/commit/2b0fec5bc3934203525b1d671c0486832233feab).
- Fixes a bug that would prevent proper deallocation of the `ThreadPool`.
- Fixes misaligned task slots.
- Fixes a case where creating a `ThreadPool`, then destroying it during an extremely small window could cause deadlock.
- Fixes improperly implemented diagnostic function `is_idle()`, changing it to match its documentation.
- Alters `tests.cpp` such that it no longer requires C++14.