### PR TITLE
Support halt / resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ This library consists of a single header and source file. One may compile the so
 
 ### Prerequisites
 
-You will require a C++11 compiler. If you are using MinGW-w64, you may require [MinGW STD Threads](https://github.com/nmcclatchey/mingw-std-threads "MinGW STD Threads") to supply std::thread and similar.
+You will require a C++11 compiler. If you are using MinGW-w64, you may require [MinGW STD Threads](https://github.com/nmcclatchey/mingw-std-threads "MinGW STD Threads") to supply `std::thread` and similar.
 
 ### Installing
 
-Either compile thread_pool.cpp as part of your project, or [compile it as a static library](https://en.wikipedia.org/wiki/Static_library "Wikipedia: Static library").
+Either compile `thread_pool.cpp` as part of your project, or [compile it as a static library](https://en.wikipedia.org/wiki/Static_library "Wikipedia: Static library").
 
 ### Using the library
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pool.schedule([](void)
 
 ## Authors
 
-* **Nathaniel J. McClatchey** - *Initial work*
+* **Nathaniel J. McClatchey, PhD** - *Initial work*
 
 ## License
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,4 +10,8 @@ The test application will, when run, perform the following:
 * Assign tasks to a `ThreadPool`.
 * Ensure that `ThreadPool`s idle when all tasks are complete, to avoid excessive CPU use. If it fails to idle quickly enough after completion, or does not complete within a reasonable period of time, the test application returns non-zero.
 * Restart an idling `ThreadPool` for a second round of tasks.
+* Test delayed scheduling of tasks.
+* Ensure that an active `ThreadPool` can be safely destroyed (losing its tasks in the process).
 * Measure how well tasks are balanced, by counting the minimum, maximum, and average number of tasks performed by each worker thread. Given that the tasks are (mostly) homogeneous, good balance is indicated by similarity of these numbers.
+* Pause and resume a `ThreadPool`.
+* Destroy a paused `ThreadPool`.

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <cstdio>
 #include <atomic>
+#include <cstdint>
 
 #define LOG(fmtString,...) printf(fmtString "\n", ##__VA_ARGS__); fflush(stdout)
 
@@ -21,7 +22,7 @@ using namespace std;
 constexpr size_t kTestMaxThreads = 1024;
 constexpr size_t kTestRootTasks = 10000;
 constexpr size_t kTestBranchFactor = 8000;
-constexpr size_t kTestTotalTasks = kTestRootTasks * kTestBranchFactor;
+constexpr uint_fast64_t kTestTotalTasks = kTestRootTasks * kTestBranchFactor;
 
 
 void perform_task (void);
@@ -85,7 +86,7 @@ int main()
   int test_id = 0;
   {
     LOG("Test %u:\t%s",++test_id,"Query static information");
-    LOG("\tWorker queue capacity is %llu tasks.",ThreadPool::get_worker_capacity());
+    LOG("\tWorker queue capacity is %zu tasks.",ThreadPool::get_worker_capacity());
   }
   {
     LOG("Test %u:\t%s",++test_id,"Construct and destroy empty threadpool.");

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -180,6 +180,76 @@ int main()
     LOG("\t%s", "Destroying the thread pool.");
   }
 
+  {
+    LOG("Test %u:\t%s",++test_id,"Pause and resume a ThreadPool with running task-chains.");
+    LOG("\t%s","Constructing a thread pool.");
+    ThreadPool pool (3);
+    LOG("\t\tDone.\tNote: Pool has %u worker threads.", pool.get_concurrency());
+    LOG("\t%s", "Scheduling several undying tasks...");
+    {
+      std::unique_lock<decltype(mtx)> guard (mtx);
+      one_is_active = false;
+      alive_count = 0;
+      for (unsigned n = 0; n < 16; ++n)
+        pool.schedule([&pool](void) { stay_active(pool); });
+      cv.wait(guard, [](void)->bool { return one_is_active; });
+    }
+    LOG("\t\t%s","Done. Tasks scheduled successfully.");
+    LOG("\t%s","Pausing...");
+    pool.halt();
+    LOG("\t%s","Waiting for 1 second...");
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    LOG("\t%s","Unpausing...");
+    pool.resume();
+    LOG("\t%s","Waiting for 0.3 seconds...");
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    LOG("\t%s", "Destroying the thread pool.");
+  }
+
+  {
+    LOG("Test %u:\t%s",++test_id,"Destroy a paused Threadpool.");
+    LOG("\t%s","Constructing a thread pool.");
+    ThreadPool pool (5);
+    LOG("\t\tDone.\tNote: Pool has %u worker threads.", pool.get_concurrency());
+    LOG("\t%s", "Scheduling several undying tasks...");
+    {
+      std::unique_lock<decltype(mtx)> guard (mtx);
+      one_is_active = false;
+      alive_count = 0;
+      for (unsigned n = 0; n < 16; ++n)
+        pool.schedule([&pool](void) { stay_active(pool); });
+      cv.wait(guard, [](void)->bool { return one_is_active; });
+    }
+    LOG("\t\t%s","Done. Tasks scheduled successfully.");
+    LOG("\t%s","Pausing...");
+    pool.halt();
+    LOG("\t%s", "Destroying the thread pool.");
+  }
+
+  {
+    LOG("Test %u:\t%s",++test_id,"Attempt to pause from within a worker thread.");
+    LOG("\t%s","Constructing a thread pool.");
+    ThreadPool pool;
+    LOG("\t\tDone.\tNote: Pool has %u worker threads.", pool.get_concurrency());
+    LOG("\t%s", "Scheduling a few tasks, including a pausing task.");
+    {
+      std::unique_lock<decltype(mtx)> guard (mtx);
+      one_is_active = false;
+      alive_count = 0;
+      for (unsigned n = 0; n < 16; ++n)
+        pool.schedule([&pool](void) { stay_active(pool); });
+      pool.schedule([&pool](void) { pool.halt(); });
+      cv.wait(guard, [](void)->bool { return one_is_active; });
+    }
+    LOG("\t\t%s","Done. Tasks scheduled successfully.");
+    LOG("\t\t%s","Done. Waiting for 1 second...");
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    LOG("\t%s","Unpausing...");
+    pool.resume();
+    LOG("\t\t%s","Done. Waiting for 1 second...");
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    LOG("\t%s", "Destroying the thread pool.");
+  }
   LOG("%s", "Exiting...");
   return logged_errors;
 }

--- a/threadpool.cpp
+++ b/threadpool.cpp
@@ -73,6 +73,17 @@ constexpr Integer lsb (Integer x) noexcept
   return ((x - 1) & x) ^ x;
 }
 
+/// \brief  Checks whether and integer is a power-of-2. Useful for alignment
+///   debugging.
+template<class Integer>
+constexpr Integer is_pow2 (Integer x) noexcept
+{
+  return ((x - 1) & x) == 0;
+}
+
+static_assert(is_pow2(THREAD_POOL_FALSE_SHARING_ALIGNMENT), "Alignments must be\
+ integer powers of 2.");
+
 /// \brief  Exactly what it says on the tin. I'd use `std::min`, but that's not
 ///   `constexpr` until C++14.
 template<class Integer1, class Integer2>
@@ -339,7 +350,11 @@ size exceeds limit of selected index type.");
 //  records the remaining size of the batch. A successfully scheduled subtask
 //  will increment this to ensure the originally scheduled tasks are completed
 //  as part of the batch.
-  std::uint_fast32_t  countdown_ : (kValidShift + 8),
+  static_assert(kLog2Modulus < sizeof(std::uint_fast32_t) * CHAR_BIT - 2, "The \
+behavior of the worker queue's starvation-avoidance algorithm has not yet been \
+examined in the case that the countdown variable is small relative to the task-\
+queue.");
+  std::uint_fast32_t  countdown_ : (sizeof(std::uint_fast32_t) * CHAR_BIT - 2),
 //    While a task is being executed, the front_ marker is not incremented. This
 //  avoids early claiming of a new task (which would prevent that task from
 //  being stolen), but makes the push-to-front process a bit more complicated.
@@ -353,8 +368,8 @@ size exceeds limit of selected index type.");
 //    Task queue. When information about the cache is available, allocate so
 //  that tasks aren't split across cache lines. Note: If splitting is
 //  inevitable, make a best-effort attempt to reduce it.
-  alignas(min(lsb(sizeof(task_type)), THREAD_POOL_FALSE_SHARING_ALIGNMENT))    \
-    char tasks_ [kModulus * sizeof(task_type)];
+  alignas(max(alignof(task_type), min(lsb(sizeof(task_type)),\
+THREAD_POOL_FALSE_SHARING_ALIGNMENT))) char tasks_ [kModulus*sizeof(task_type)];
 };
 
 Worker::Worker (ThreadPoolImpl & pool) noexcept

--- a/threadpool.cpp
+++ b/threadpool.cpp
@@ -4,9 +4,8 @@
 /// \copyright Copyright (c) 2017 Nathaniel J. McClatchey, PhD.               \n
 ///   Licensed under the MIT license.                                         \n
 ///   You should have received a copy of the license with this software.
-/// \note   To compile for MinGW-w64 without linking against the winpthreads
-/// library, use the <a href=https://github.com/nmcclatchey/mingw-std-threads>
-/// MinGW Windows STD Threads library</a>.
+/// \note   To compile for MinGW-w64 without linking against the *winpthreads*
+/// library, use the [*MinGW Windows STD Threads* library](https://github.com/nmcclatchey/mingw-std-threads).
 #include "threadpool.hpp"
 
 #if !defined(__cplusplus) || (__cplusplus < 201103L)
@@ -801,6 +800,7 @@ void Worker::operator() (void)
   {
     std::unique_lock<mutex_type> guard(mutex);
     ++pool_.living_;
+    guard.unlock();
     pool_.cv_.notify_all();
   }
 //  The thread is started after all workers are initialized; no need to wait.
@@ -904,6 +904,7 @@ kill:
   {
     std::unique_lock<mutex_type> guard (mutex);
     --pool_.living_;
+    guard.unlock();
     pool_.cv_.notify_all();
   }
 }

--- a/threadpool.hpp
+++ b/threadpool.hpp
@@ -236,11 +236,12 @@ struct ThreadPool
 /// function returns the number of tasks that each worker can keep in its own
 /// queue -- that is, the number of tasks that a worker can have scheduled
 /// before contention occurs.                                                 \n
-///   Selection of the size of the queue may be done in `thread_pool.cpp` by
-/// editing If the returned value is large, many tasks may be simultaneously scheduled
+///   If the returned value is large, many tasks may be simultaneously scheduled
 /// without taking the slow path, but more memory is required. If it is small,
 /// task scheduling is more likely to take the slow path, but less memory is
-/// required.
+/// required.                                                                 \n
+///   To select the size of the worker queues, edit the variable `kLog2Modulus`
+/// in `thread_pool.cpp`.
   static std::size_t get_worker_capacity (void);
 
 /// \brief  Returns whether the pool is currently idle.

--- a/threadpool.hpp
+++ b/threadpool.hpp
@@ -4,8 +4,8 @@
 ///
 ///   This header is part of a multi-tasking library that provides low-overhead
 /// concurrent scheduling. This is provided through a thread pool, and uses the
-/// <a href=https://en.wikipedia.org/wiki/Work_stealing>work-stealing method</a>
-/// for work balancing.                                                       \n
+/// [work-stealing method](https://en.wikipedia.org/wiki/Work_stealing) for load
+/// balancing.                                                           \n
 ///   This averts the overhead of creating a new thread for each task, and thus
 /// makes fine-grained parallelism feasible.
 /// \code
@@ -62,13 +62,13 @@
 ///   is 64 bytes, as this is typical of x86 and x64 systems.
 /// \note Users may specify the capacity of each worker's fixed queue by
 ///   changing the definition of `kLog2Modulus` in \ref `thread_pool.cpp`.
-/// \todo Allow tasks to return values, possibly using std::packaged_task.
-/// \todo Investigate delegates as a replacement for std::function:
-///   <a href=https://www.codeproject.com/Articles/1170503/The-Impossibly-Fast-Cplusplus-Delegates-Fixed>"The Impossibly Fast C++ Delegates (Fixed)"</href>
+/// \todo Allow tasks to return values, possibly using `std::packaged_task`.
+/// \todo Investigate delegates as a replacement for `std::function`:
+///   ["The Impossibly Fast C++ Delegates (Fixed)"](https://www.codeproject.com/Articles/1170503/The-Impossibly-Fast-Cplusplus-Delegates-Fixed)
 /// \author Nathaniel J. McClatchey, PhD
-/// \version  1.3.0
+/// \version  1.4.0
 /// \copyright Copyright (c) 2017 Nathaniel J. McClatchey, PhD.               \n
-///   Licensed under the MIT license.                                         \n
+///   [Licensed under the MIT license.](https://github.com/nmcclatchey/ThreadPool/blob/master/LICENSE)  \n
 ///   You should have received a copy of the license with this software.
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -132,6 +132,8 @@ struct ThreadPool
 /// until they terminate. Though any task that has already been started will be
 /// completed, any tasks that are not active when `~ThreadPool()` is called
 /// may be forgotten.
+/// \warning  Using a worker thread to destroy its own `ThreadPool` results in
+///   undefined behavior.
   ~ThreadPool (void);
 
 //  Thread pools cannot be copied or moved.
@@ -242,12 +244,38 @@ struct ThreadPool
   static std::size_t get_worker_capacity (void);
 
 /// \brief  Returns whether the pool is currently idle.
-/// \return \c true if the pool is idle, or \c false if not.
+/// \return `true` if the pool is idle, or `false` if not.
 ///
 ///   Returns whether the pool is idle. That is, returns true if all threads in
-/// the pool are simultaneously idling, or fales if at least one thread is
-/// active. May return \c false spuriously.
+/// the pool are simultaneously idling, or `false` if at least one thread is
+/// active. If the pool is halted, the returned value is undefined. Calling this
+/// from within one of the `ThreadPool`'s tasks necessarily returns `false`.
   bool is_idle (void) const;
+
+/// \brief  Suspends execution of tasks in the `ThreadPool`.
+///
+///   Halts all worker threads, blocking the caller until worker threads have
+/// fully halted. If `halt()` is called from within one of the pool's worker
+/// threads, the calling thread is halted either until `resume()` is called or
+/// until the `ThreadPool` is destroyed, whichever comes first.
+/// \see  `resume()`
+  void halt (void);
+
+/// \brief  Resumes execution of tasks in the `ThreadPool` after a call to
+///   `halt()`.
+///
+///   If execution is currently halted, re-starts all worker threads, possibly
+/// blocking the caller until all worker threads have resumed their tasks.
+/// \see  `halt()`
+  void resume (void);
+
+/// \brief  Returns whether the pool is currently halted.
+/// \return Returns `true` if all worker threads are halted, or `false` if not.
+///
+///   Returns whether the pool is currently halted. Note that this function only
+/// begins to return `true` once all tasks have fully halted. Calling it from
+/// within one of the `ThreadPool`'s tasks necessarily returns `false`.
+  bool is_halted (void) const;
  private:
   void * impl_;
   typedef std::chrono::steady_clock::duration duration;


### PR DESCRIPTION
This PR adds `halt()` and `resume()` member functions to `ThreadPool`. As the names imply, `halt()` causes all the pool to perform no further tasks (after any currently-active tasks complete), and `resume()` resumes normal operation. This might prove to be useful for debugging, though its suitability for other purposes remains in question.

To further aid debugging, a diagnostic function `is_halted()` has been added so that users may detect the whether a `ThreadPool` has been halted.